### PR TITLE
Increase <nav> consistency

### DIFF
--- a/brand.html
+++ b/brand.html
@@ -64,13 +64,20 @@
     <section class="chunk introduction">
         <div class="nav_div">
             <nav class="introduction_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/bannerless.png" type="image/png"> 
                         <img src="img/logo/bannerless.png" alt="Team logo picture">
                     </picture>
                     <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/full.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/full.png" type="image/png"> 
+                        <img src="img/logo/full.png" alt="Team logo picture">
+                    </picture>
                 </div>
                 <div class="right_nav">
                     <a class="nav_link" href="competitions.html">Competitions</a>
@@ -105,7 +112,15 @@
     <section class="chunk guidelines">
         <div class="nav_div">
             <nav class="guidelines_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/bannerless.png" type="image/png"> 
+                        <img src="img/logo/bannerless.png" alt="Team logo picture">
+                    </picture>
+                    <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/full.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/full.png" type="image/png"> 
@@ -248,7 +263,15 @@
     <section class="chunk download">
         <div class="nav_div">
             <nav class="download_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/bannerless.png" type="image/png"> 
+                        <img src="img/logo/bannerless.png" alt="Team logo picture">
+                    </picture>
+                    <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/full.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/full.png" type="image/png"> 
@@ -264,7 +287,7 @@
         <div class="content_div">
             <h2 class="sub_text">Download</h2>
             <div class="fl fl_row fl_wrap fl_direction_space-around">
-                
+
                 <div onmouseover="bannerless_appear();" onmouseout="bannerless_disappear();" class="download_box">
                     <picture class="guideline_photo" style="width: 240px; height: 200px;">
                         <source srcset="img/brand/Bannerless.webp" type="image/webp">
@@ -320,7 +343,15 @@
     <footer>
         <div class="nav_div">
             <nav class="footer_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/bannerless.png" type="image/png"> 
+                        <img src="img/logo/bannerless.png" alt="Team logo picture">
+                    </picture>
+                    <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/full.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/full.png" type="image/png"> 

--- a/competitions.html
+++ b/competitions.html
@@ -60,13 +60,20 @@
     <section class="chunk houston">
         <div class="nav_div">
             <nav class="houston_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/bannerless.png" type="image/png"> 
                         <img src="img/logo/bannerless.png" alt="Team logo picture">
                     </picture>
                     <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/full.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/full.png" type="image/png"> 
+                        <img src="img/logo/full.png" alt="Team logo picture">
+                    </picture>
                 </div>
                 <div class="right_nav">
                     <a class="nav_link" href="competitions.html">Competitions</a>
@@ -98,7 +105,15 @@
     <section class="chunk pacific">
         <div class="nav_div">
             <nav class="pacific_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/bannerless.png" type="image/png"> 
+                        <img src="img/logo/bannerless.png" alt="Team logo picture">
+                    </picture>
+                    <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/full.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/full.png" type="image/png"> 
@@ -137,7 +152,15 @@
     <footer>
         <div class="nav_div">
             <nav class="footer_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/bannerless.png" type="image/png"> 
+                        <img src="img/logo/bannerless.png" alt="Team logo picture">
+                    </picture>
+                    <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/full.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/full.png" type="image/png"> 

--- a/css/main.css
+++ b/css/main.css
@@ -99,7 +99,6 @@ section:first-child > .nav_div > nav > .bannerless_nav {
     display: flex;
 }
 
-
 .right_nav {
     width: 20%;
     display: -ms-flexbox;

--- a/css/main.css
+++ b/css/main.css
@@ -86,6 +86,19 @@ nav>div {
     cursor: pointer;
 }
 
+/* Next 3 rules allow for a copy paste nav check #27 */
+.bannerless_nav {
+    display: none;
+}
+        
+section:first-child > .nav_div > nav > .full_nav {
+    display: none;
+}
+
+section:first-child > .nav_div > nav > .bannerless_nav {
+    display: flex;
+}
+
 
 .right_nav {
     width: 20%;
@@ -313,10 +326,4 @@ h3 {
 .b_git {
     background-color: #181717;
     color: white;
-}
-
-
-
-.full_nav:first-child {
-    background: red;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -86,6 +86,7 @@ nav>div {
     cursor: pointer;
 }
 
+
 .right_nav {
     width: 20%;
     display: -ms-flexbox;
@@ -312,4 +313,10 @@ h3 {
 .b_git {
     background-color: #181717;
     color: white;
+}
+
+
+
+.full_nav:first-child {
+    background: red;
 }

--- a/index.html
+++ b/index.html
@@ -58,13 +58,20 @@
     <section class="chunk first">
         <div class="nav_div">
             <nav class="first_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/bannerless.png" type="image/png"> 
                         <img src="img/logo/bannerless.png" alt="Team logo picture">
                     </picture>
                     <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/full.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/full.png" type="image/png"> 
+                        <img src="img/logo/full.png" alt="Team logo picture">
+                    </picture>
                 </div>
                 <div class="right_nav">
                     <a class="nav_link" href="competitions.html">Competitions</a>
@@ -94,7 +101,15 @@
     <section class="chunk second">
         <div class="nav_div">
             <nav class="second_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/bannerless.png" type="image/png"> 
+                        <img src="img/logo/bannerless.png" alt="Team logo picture">
+                    </picture>
+                    <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/full.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/full.png" type="image/png"> 
@@ -131,7 +146,15 @@
     <section class="chunk third">
         <div class="nav_div">
             <nav class="third_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/bannerless.png" type="image/png"> 
+                        <img src="img/logo/bannerless.png" alt="Team logo picture">
+                    </picture>
+                    <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/full.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/full.png" type="image/png"> 
@@ -173,7 +196,15 @@
     <section class="chunk forth">
         <div class="nav_div">
             <nav class="forth_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/bannerless.png" type="image/png"> 
+                        <img src="img/logo/bannerless.png" alt="Team logo picture">
+                    </picture>
+                    <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/full.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/full.png" type="image/png"> 
@@ -227,7 +258,15 @@
     <footer>
         <div class="nav_div">
             <nav class="footer_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/bannerless.png" type="image/png"> 
+                        <img src="img/logo/bannerless.png" alt="Team logo picture">
+                    </picture>
+                    <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/full.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/full.png" type="image/png"> 

--- a/sponsors.html
+++ b/sponsors.html
@@ -61,13 +61,20 @@
     <section class="chunk platinum">
         <div class="nav_div">
             <nav class="platinum_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/bannerless.png" type="image/png"> 
                         <img src="img/logo/bannerless.png" alt="Team logo picture">
                     </picture>
                     <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/full.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/full.png" type="image/png"> 
+                        <img src="img/logo/full.png" alt="Team logo picture">
+                    </picture>
                 </div>
                 <div class="right_nav">
                     <a class="nav_link" href="competitions.html">Competitions</a>
@@ -96,7 +103,15 @@
     <section class="chunk bronze">
         <div class="nav_div">
             <nav class="bronze_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/bannerless.png" type="image/png"> 
+                        <img src="img/logo/bannerless.png" alt="Team logo picture">
+                    </picture>
+                    <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/full.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/full.png" type="image/png"> 
@@ -128,7 +143,15 @@
     <footer>
         <div class="nav_div">
             <nav class="footer_nav">
-                <div class="left_nav" onclick="window.location.assign('https://frc7787.ca')">
+                <div class="left_nav bannerless_nav" onclick="window.location.assign('https://frc7787.ca')">
+                    <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
+                        <source srcset="img/logo/bannerless.webp" sizes="" type="image/webp">
+                        <source srcset="img/logo/bannerless.png" type="image/png"> 
+                        <img src="img/logo/bannerless.png" alt="Team logo picture">
+                    </picture>
+                    <h1 class="reybots">Reynolds Reybots</h1>
+                </div>
+                <div class="left_nav full_nav" onclick="window.location.assign('https://frc7787.ca')">
                     <picture class="nav_bar_picture" style="width: 60px; height: 60px;">
                         <source srcset="img/logo/full.webp" sizes="" type="image/webp">
                         <source srcset="img/logo/full.png" type="image/png"> 


### PR DESCRIPTION
# Copy paste nav

### Objective:
Make the elements inside `<nav>` consistent between all the sections. Right now they are different for displaying an extended branding information in the first section nav while a constrained one in the others. This PR intends to maintain this functionality while making the contents consistent. 

### How (brief)
Using the `:first-child` pseudo-selector on the section element you can make that some styles only apply to the first `<section>`

### Reason
For increasing maintainability.

### Notes
- Javascript was avoided intentionally
- Similar solution should be applied for the section colors, avoiding the use of specific class names
